### PR TITLE
Unblock publishing: reset + cap oversized history.jsonl

### DIFF
--- a/.github/workflows/publish-allure-report.yml
+++ b/.github/workflows/publish-allure-report.yml
@@ -48,6 +48,35 @@ jobs:
       - name: Generate Allure Report 🔧
         run: make report-build
 
+      # Bound history.jsonl so it can never cross GitHub's 100 MB per-file push
+      # limit again. `allure generate` (historyPath: ./history.jsonl in
+      # allurerc.mjs) appends one run snapshot per line, oldest first, each
+      # carrying the full knownTestCaseIds set - so the file grows both per run
+      # and per test, and previously reached ~101 MB (83 runs) which made every
+      # publish push fail. Keep only the most recent runs, capped by BOTH a run
+      # count and a hard byte budget well under the limit; the byte budget also
+      # guards against a single run's snapshot ballooning as the test suite grows.
+      - name: Cap Allure trend history
+        run: |
+          set -euo pipefail
+          HIST=history.jsonl
+          if [ ! -f "$HIST" ]; then
+            echo "No $HIST to cap (fresh history)."
+            exit 0
+          fi
+          MAX_RUNS=25
+          MAX_BYTES=$((80 * 1024 * 1024))
+          before_lines=$(wc -l < "$HIST"); before_bytes=$(wc -c < "$HIST")
+          # 1) cap by run count - keep the last MAX_RUNS lines (newest are last)
+          tail -n "$MAX_RUNS" "$HIST" > "$HIST.capped"
+          # 2) cap by size - drop oldest remaining lines until under the budget
+          while [ "$(wc -c < "$HIST.capped")" -gt "$MAX_BYTES" ] && [ "$(wc -l < "$HIST.capped")" -gt 1 ]; do
+            tail -n +2 "$HIST.capped" > "$HIST.capped.tmp"
+            mv "$HIST.capped.tmp" "$HIST.capped"
+          done
+          mv "$HIST.capped" "$HIST"
+          echo "history.jsonl capped: ${before_lines} runs/${before_bytes}B -> $(wc -l < "$HIST") runs/$(wc -c < "$HIST")B"
+
       - name: Commit & push updated history
         uses: stefanzweifel/git-auto-commit-action@v7
         with:

--- a/.github/workflows/publish-allure-report.yml
+++ b/.github/workflows/publish-allure-report.yml
@@ -32,6 +32,11 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
+    env:
+      # Bounds for cap-history.sh so history.jsonl can never cross GitHub's
+      # 100 MB per-file push limit. Tune here without touching the script.
+      HISTORY_MAX_RUNS: "25"
+      HISTORY_MAX_BYTES: "94371840" # 90 MiB strict ceiling (< GitHub's 100 MB limit)
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v6.0.2
@@ -45,37 +50,19 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Cap the committed seed BEFORE generating, so the report itself is built
+      # from a bounded trend history (see cap-history.sh for the why + bounds).
+      - name: Cap Allure trend history (seed)
+        run: bash ./cap-history.sh
+
       - name: Generate Allure Report 🔧
         run: make report-build
 
-      # Bound history.jsonl so it can never cross GitHub's 100 MB per-file push
-      # limit again. `allure generate` (historyPath: ./history.jsonl in
-      # allurerc.mjs) appends one run snapshot per line, oldest first, each
-      # carrying the full knownTestCaseIds set - so the file grows both per run
-      # and per test, and previously reached ~101 MB (83 runs) which made every
-      # publish push fail. Keep only the most recent runs, capped by BOTH a run
-      # count and a hard byte budget well under the limit; the byte budget also
-      # guards against a single run's snapshot ballooning as the test suite grows.
-      - name: Cap Allure trend history
-        run: |
-          set -euo pipefail
-          HIST=history.jsonl
-          if [ ! -f "$HIST" ]; then
-            echo "No $HIST to cap (fresh history)."
-            exit 0
-          fi
-          MAX_RUNS=25
-          MAX_BYTES=$((80 * 1024 * 1024))
-          before_lines=$(wc -l < "$HIST"); before_bytes=$(wc -c < "$HIST")
-          # 1) cap by run count - keep the last MAX_RUNS lines (newest are last)
-          tail -n "$MAX_RUNS" "$HIST" > "$HIST.capped"
-          # 2) cap by size - drop oldest remaining lines until under the budget
-          while [ "$(wc -c < "$HIST.capped")" -gt "$MAX_BYTES" ] && [ "$(wc -l < "$HIST.capped")" -gt 1 ]; do
-            tail -n +2 "$HIST.capped" > "$HIST.capped.tmp"
-            mv "$HIST.capped.tmp" "$HIST.capped"
-          done
-          mv "$HIST.capped" "$HIST"
-          echo "history.jsonl capped: ${before_lines} runs/${before_bytes}B -> $(wc -l < "$HIST") runs/$(wc -c < "$HIST")B"
+      # Cap again AFTER generating: `allure generate` appends this run's snapshot
+      # back to history.jsonl, so the file committed and pushed below must be
+      # re-bounded or it would creep back over GitHub's 100 MB push limit.
+      - name: Cap Allure trend history (post-generate)
+        run: bash ./cap-history.sh
 
       - name: Commit & push updated history
         uses: stefanzweifel/git-auto-commit-action@v7

--- a/cap-history.sh
+++ b/cap-history.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# Bound the Allure trend history file so it can never cross GitHub's 100 MB
+# per-file push limit (which previously broke every "Publish Report to GitHub
+# Pages" run once history.jsonl reached ~101 MB).
+#
+# history.jsonl is JSONL: one run snapshot per line, oldest line first, each
+# snapshot carrying the full knownTestCaseIds set - so it grows both per run and
+# per test. `allure generate` (historyPath: ./history.jsonl in allurerc.mjs)
+# reads it to seed the trend and rewrites it with the current run appended.
+#
+# This script keeps only the most recent runs, bounded by BOTH a run count and a
+# hard byte budget, and is run on BOTH sides of `make report-build`:
+#   - before: the report is generated from an already-bounded seed
+#   - after:  the file committed back to the repo (the one that gets pushed) is
+#             bounded regardless of the run appended during generation
+#
+# Tunable via env (with safe defaults):
+#   HISTORY_MAX_RUNS  - max run snapshots (lines) to retain             [25]
+#   HISTORY_MAX_BYTES - hard byte ceiling, strictly enforced; drop oldest
+#                       lines until under it, and if even a single snapshot
+#                       still exceeds it, reset to a fresh history rather than
+#                       commit an over-budget file                      [90 MiB]
+#
+# HISTORY_MAX_BYTES is a strict maximum: the file written back is always at or
+# below it (well under GitHub's 100 MB per-file limit). Default leaves headroom.
+#
+# Usage: cap-history.sh [path-to-history.jsonl]   (default: history.jsonl)
+
+set -euo pipefail
+
+HIST="${1:-history.jsonl}"
+MAX_RUNS="${HISTORY_MAX_RUNS:-25}"
+MAX_BYTES="${HISTORY_MAX_BYTES:-$((90 * 1024 * 1024))}"
+
+if [ ! -f "$HIST" ]; then
+  echo "cap-history: no $HIST to cap (fresh history)."
+  exit 0
+fi
+
+before_lines=$(wc -l < "$HIST")
+before_bytes=$(wc -c < "$HIST")
+
+# 1) Cap by run count: keep the last MAX_RUNS lines (newest are last).
+tail -n "$MAX_RUNS" "$HIST" > "$HIST.capped"
+
+# 2) Cap by size (strict): keep the newest complete lines whose cumulative bytes
+#    are <= MAX_BYTES, in a single pass. If even the newest snapshot alone
+#    exceeds MAX_BYTES it cannot be trimmed further, so this yields an empty file
+#    - a reset to fresh history, which is the intended strict-enforcement
+#    failsafe (a lone snapshot near 100 MB is pathological; losing it beats
+#    re-breaking every deploy). LC_ALL=C makes awk count bytes, not characters,
+#    so the budget is byte-accurate against GitHub's per-file limit.
+LC_ALL=C awk -v max="$MAX_BYTES" '
+  { line[NR] = $0; len[NR] = length($0) + 1 }   # +1 for the newline
+  END {
+    total = 0; start = NR + 1
+    for (i = NR; i >= 1; i--) { total += len[i]; if (total > max) break; start = i }
+    for (i = start; i <= NR; i++) print line[i]
+  }
+' "$HIST.capped" > "$HIST.sized"
+
+if [ ! -s "$HIST.sized" ] && [ -s "$HIST.capped" ]; then
+  echo "cap-history: WARNING - newest snapshot exceeds ${MAX_BYTES} bytes; reset to fresh history."
+fi
+
+mv "$HIST.sized" "$HIST"
+rm -f "$HIST.capped"
+echo "cap-history: ${before_lines} runs/${before_bytes}B -> $(wc -l < "$HIST") runs/$(wc -c < "$HIST")B"


### PR DESCRIPTION
## Problem

The **Publish Report to GitHub Pages** workflow has been failing on every run. Its "Commit & push updated history" step pushes `history.jsonl` back to `master`, but the file had grown to **~101 MB (83 run snapshots)** - over GitHub's **100 MB per-file push limit** - so every push was rejected (`pre-receive hook declined`), the build job failed, and `deploy` was skipped. No report has deployed for hours; every dashboard view (including the new **Connection Lifecycle** report) is stale and `https://qa.meshery.io/connections/` 404s.

## Root cause

`allure generate` (`historyPath: "./history.jsonl"` in `allurerc.mjs`) appends one run snapshot per line and never bounds the file. Each snapshot also embeds the full `knownTestCaseIds` set, so it grows **both per run and per test** (83 lines x ~1.26 MB).

## Fix (reset + cap)

- **Reset:** remove the oversized committed `history.jsonl`. The next publish regenerates a fresh, small one - `report-build` already treats a missing file as "first run". Only historical trend charts are lost; **no test results are affected**.
- **Cap:** add a `Cap Allure trend history` step **before** the commit step that keeps only the most recent runs, bounded by **both** a run count (`MAX_RUNS=25`) **and** a hard byte budget (`MAX_BYTES=80 MB`), so the file can never approach the 100 MB limit again. The byte budget also guards against a single snapshot ballooning as the suite grows.

Verified the cap on the real 83-run/105 MB file: `-> 25 runs / 32 MB`, every retained line valid JSON, newest snapshot preserved.

Minimal and qa-scoped; no git-history rewrite (past large blobs are a separate, optional cleanup that does not block publishing).

## Post-merge

The publish workflow does not trigger on `.github/**` changes, so I will dispatch a `Publish Report to GitHub Pages` run after merge and confirm it **succeeds** and that `https://qa.meshery.io/connections/` returns 200 with the Connection Lifecycle report.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Allure report publishing by limiting history to the newest configured runs.
  * Prevented history files from exceeding configured size limits, with a 95 MiB failsafe to protect report publishing.
  * Added automatic cleanup of older history entries while preserving recent report data.
  * Added logging for history entry counts and file sizes before and after cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->