### PR TITLE
[QA] Rename connections report to "Meshery: Connections Lifecycle"

### DIFF
--- a/allurerc.mjs
+++ b/allurerc.mjs
@@ -35,11 +35,8 @@ const CONNECTION_LIFECYCLE_GROUP = "Connection Lifecycle";
 
 // The connection report's DISPLAY name, decoupled from the filter key above so
 // the report can be renamed without breaking the testGroup match. The
-// "Meshery: " prefix presents it as a Meshery report in the dashboard's report
-// picker (lightweight nesting under the main Meshery report) - Allure 3 reports
-// are flat peer plugins with no parent/child nesting in the config, so the
-// prefix is the supported way to signal the relationship. See the connections
-// plugin block below.
+// "Meshery: " prefix is intentional - see the connections plugin block below
+// for the nesting rationale (kept in one place to avoid drift).
 const CONNECTION_REPORT_NAME = "Meshery: Connections Lifecycle";
 
 // --- Transitional epic-based fallback (remove once all connection results

--- a/allurerc.mjs
+++ b/allurerc.mjs
@@ -26,10 +26,21 @@ const isTestGroup = (labels, groupName) =>
 
 const hasTestGroup = (labels) => labels.some(({ name }) => name === "testGroup");
 
-// Single source of truth for the Connection Lifecycle Test Group value - used
-// for both the report display name and the testGroup filter so the two cannot
-// drift apart.
+// The Connection Lifecycle Test Group VALUE - this is the `testGroup` label
+// value the tests emit (Test Plan "Latest" tab, col B), so it is the report's
+// FILTER key and MUST match the value tagged at the source (UI specs + CLI
+// converter). Do NOT change it to rename the report - the display name is a
+// separate constant below.
 const CONNECTION_LIFECYCLE_GROUP = "Connection Lifecycle";
+
+// The connection report's DISPLAY name, decoupled from the filter key above so
+// the report can be renamed without breaking the testGroup match. The
+// "Meshery: " prefix presents it as a Meshery report in the dashboard's report
+// picker (lightweight nesting under the main Meshery report) - Allure 3 reports
+// are flat peer plugins with no parent/child nesting in the config, so the
+// prefix is the supported way to signal the relationship. See the connections
+// plugin block below.
+const CONNECTION_REPORT_NAME = "Meshery: Connections Lifecycle";
 
 // --- Transitional epic-based fallback (remove once all connection results
 // carry testGroup) -----------------------------------------------------------
@@ -155,7 +166,16 @@ export default defineConfig({
     //
     // The plugin key stays `connections` so the published report URL
     // (https://qa.meshery.io/connections/) is unchanged; only the display name
-    // and filter change.
+    // changes (reportName = CONNECTION_REPORT_NAME, "Meshery: Connections
+    // Lifecycle"). The filter (isTestGroup "Connection Lifecycle") is unchanged.
+    //
+    // Nesting: the "Meshery: " prefix presents this as a Meshery report in the
+    // dashboard's report picker. Allure 3 reports are flat peer plugins (the
+    // config `plugins` map has no parent/child relation, and the awesome
+    // plugin's only hierarchy is intra-report `groupBy`), so a name prefix is
+    // the supported way to signal that this is a subset of the main Meshery
+    // report; true report-under-report nesting is not available without folding
+    // these results into the Meshery report and losing the standalone URL.
     //
     // Transitional: the isConnectionBehavior (epic) fallback keeps the report
     // populated with connection results emitted before the testGroup label
@@ -167,7 +187,7 @@ export default defineConfig({
     connections: {
       import: "@allurereport/plugin-awesome",
       options: {
-        reportName: CONNECTION_LIFECYCLE_GROUP,
+        reportName: CONNECTION_REPORT_NAME,
         singleFile: false,
         reportLanguage: "en",
         open: false,


### PR DESCRIPTION
## What

Rename the `connections` awesome-plugin report's display name to **"Meshery: Connections Lifecycle"** in `allurerc.mjs`, and decouple that display name from the `testGroup` filter key.

## Why

- The report is fed by connection tests from both the UI (`project=Meshery`) and CLI (`project=mesheryctl`) lanes, keyed on the `testGroup=Connection Lifecycle` label. The captain asked to present it as a **subset of the main Meshery report** rather than a peer.
- Previously a single constant (`CONNECTION_LIFECYCLE_GROUP`) drove **both** the `reportName` and the `isTestGroup` filter, so the two could not be renamed independently. This splits out `CONNECTION_REPORT_NAME` for the display name; the filter still keys on the `"Connection Lifecycle"` `testGroup` value the tests emit, so the match is unchanged.

## Stable surface

- Plugin key stays `connections` -> the published URL **https://qa.meshery.io/connections/** is unchanged.
- Filter unchanged (`isTestGroup "Connection Lifecycle"` + the transitional epic fallback).
- `groupBy: ["client", "suite", "subSuite"]` unchanged.

## Nesting - investigation result

Allure 3 reports are **flat peer plugins**: the config `plugins` map has no parent/child relation, and the awesome plugin's only hierarchy is intra-report `groupBy`. There is no clean, supported way to nest one report *under* another. The **"Meshery: " name prefix** is the supported way to signal that this report is a subset of the main Meshery report in the dashboard's report picker; it is implemented here and documented inline. True report-under-report nesting would require folding these results into the Meshery report and **losing the standalone `/connections/` URL**, which this PR deliberately keeps stable. Whether to go further than the prefix is a product/architecture decision left to the maintainers.

## Verification

- `node --check allurerc.mjs` passes.
- Report-name verification at qa.meshery.io/connections happens on the next dashboard publish.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the distinction between the connection report’s display name and its filtering key.
  * Documented that the standalone connection report URL remains unchanged.

* **Bug Fixes**
  * Improved connection report labeling without affecting existing filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->